### PR TITLE
fix: credential_id too short

### DIFF
--- a/internal/db/migrations/000016_change_credential_id_len.down.sql
+++ b/internal/db/migrations/000016_change_credential_id_len.down.sql
@@ -1,0 +1,6 @@
+ALTER TABLE joy_id_infos
+    MODIFY credential_id varchar(100) DEFAULT '' NOT NULL;
+ALTER TABLE joy_id_info_versions
+    MODIFY credential_id varchar(100) DEFAULT '' NOT NULL;
+ALTER TABLE sub_key_infos
+    MODIFY credential_id varchar(100) DEFAULT '' NOT NULL;

--- a/internal/db/migrations/000016_change_credential_id_len.up.sql
+++ b/internal/db/migrations/000016_change_credential_id_len.up.sql
@@ -1,0 +1,6 @@
+ALTER TABLE joy_id_infos
+    MODIFY credential_id varchar(1500) DEFAULT '' NOT NULL;
+ALTER TABLE joy_id_info_versions
+    MODIFY credential_id varchar(1500) DEFAULT '' NOT NULL;
+ALTER TABLE sub_key_infos
+    MODIFY credential_id varchar(1500) DEFAULT '' NOT NULL;


### PR DESCRIPTION
https://w3c.github.io/webauthn/#credential-id

credential_id At most 1023 bytes long.